### PR TITLE
chore(deps): expand Renovate config + add version policy (Step 9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
       - name: Upload static analysis reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: static-analysis-reports
           path: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,38 @@ When upgrading ktlint: run `./gradlew spotlessApply` after the bump,
 check for new IDE diagnostics, and add `.editorconfig` overrides for any
 newly-misbehaving rules.
 
+## Version Policy
+
+**Default: use the latest stable version of every dependency.**
+Renovate keeps minor/patch updates current; bump majors manually
+with release-note review.
+
+Document any pin or downgrade with a `# Why pinned:` comment in
+`libs.versions.toml`. Known exception classes:
+
+1. **Kotlin + KSP lockstep** — KSP minor must match Kotlin minor
+   (e.g. Kotlin `2.3.21` requires KSP `2.3.x`). Renovate's
+   `kotlin` group enforces this.
+2. **Static-analysis on fresh Kotlin majors** — Detekt typically
+   lags new Kotlin releases by 1–3 months. Stay on the latest
+   pre-release / alpha that supports your Kotlin version until a
+   stable one lands.
+3. **Plugin AGP compatibility windows** — e.g. `dependency-analysis`
+   declares supported AGP ranges. Check the plugin's docs before
+   bumping AGP.
+4. **CI emulator images** — pin to the most stable image, not the
+   newest. New API images take months to stabilize.
+5. **Private deps** (`common-utils`, `oneui-design`) — excluded from
+   Renovate; bump manually.
+6. **Android Lint** ships with AGP — no separate dep to track. The
+   `lint-baseline.xml` file IS allowed to grow on AGP bumps; review
+   the diff but don't gate on it.
+
+After touching `libs.versions.toml` or any `build.gradle.kts` dep
+block: run `./gradlew lintDebug` before pushing (catches
+`NewerVersionAvailable`). The pre-commit hook only runs
+`spotlessCheck` — lint is manual.
+
 ## Finding Code
 
 - `de.lemke.geticon` package (`app/src/main/java/de/lemke/geticon/`) is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,9 +163,7 @@ Document any pin or downgrade with a `# Why pinned:` comment in
    bumping AGP.
 4. **CI emulator images** — pin to the most stable image, not the
    newest. New API images take months to stabilize.
-5. **Private deps** (`common-utils`, `oneui-design`) — excluded from
-   Renovate; bump manually.
-6. **Android Lint** ships with AGP — no separate dep to track. The
+5. **Android Lint** ships with AGP — no separate dep to track. The
    `lint-baseline.xml` file IS allowed to grow on AGP bumps; review
    the diff but don't gate on it.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,32 +140,9 @@ plugin mode is changed to `MANUAL`, this breaks — keep `DISTRACT_FREE`.
 
 When upgrading ktlint: run `./gradlew spotlessApply` after the bump,
 check for new IDE diagnostics, and add `.editorconfig` overrides for any
-newly-misbehaving rules.
+newly misbehaving rules.
 
 ## Version Policy
-
-**Default: use the latest stable version of every dependency.**
-Renovate keeps minor/patch updates current; bump majors manually
-with release-note review.
-
-Document any pin or downgrade with a `# Why pinned:` comment in
-`libs.versions.toml`. Known exception classes:
-
-1. **Kotlin + KSP lockstep** — KSP minor must match Kotlin minor
-   (e.g. Kotlin `2.3.21` requires KSP `2.3.x`). Renovate's
-   `kotlin` group enforces this.
-2. **Static-analysis on fresh Kotlin majors** — Detekt typically
-   lags new Kotlin releases by 1–3 months. Stay on the latest
-   pre-release / alpha that supports your Kotlin version until a
-   stable one lands.
-3. **Plugin AGP compatibility windows** — e.g. `dependency-analysis`
-   declares supported AGP ranges. Check the plugin's docs before
-   bumping AGP.
-4. **CI emulator images** — pin to the most stable image, not the
-   newest. New API images take months to stabilize.
-5. **Android Lint** ships with AGP — no separate dep to track. The
-   `lint-baseline.xml` file IS allowed to grow on AGP bumps; review
-   the diff but don't gate on it.
 
 After touching `libs.versions.toml` or any `build.gradle.kts` dep
 block: run `./gradlew lintDebug` before pushing (catches

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ coroutines = "1.11.0"
 datastore-preferences = "1.2.1"
 dependency-analysis = "3.13.0"
 detekt = "2.0.0-alpha.3"
-gradle = "9.2.1"
+agp = "9.2.1"
 hilt = "2.59.2"
 junit-android-framework = "2.0.1"
 junit5 = "6.1.0"
@@ -74,7 +74,7 @@ unit-test = ["kotest-runner-junit5", "kotest-assertions-core", "kotest-property"
 
 [plugins]
 aboutlibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutlibraries" }
-android-application = { id = "com.android.application", version.ref = "gradle" }
+android-application = { id = "com.android.application", version.ref = "agp" }
 android-junit = { id = "de.mannodermaus.android-junit", version.ref = "junit-android-framework" }
 dependency-analysis = { id = "com.autonomousapps.dependency-analysis", version.ref = "dependency-analysis" }
 detekt = { id = "dev.detekt", version.ref = "detekt" }

--- a/renovate.json
+++ b/renovate.json
@@ -28,7 +28,6 @@
         "app.cash.turbine:**",
         "com.google.dagger:**",
         "com.google.dagger.hilt.android",
-        "io.ktor:**",
         "org.jetbrains.kotlinx:kotlinx-coroutines-**"
       ],
       "automerge": true
@@ -61,12 +60,6 @@
       "matchPackageNames": [
         "io.kotest:**",
         "de.mannodermaus.android-junit"
-      ]
-    },
-    {
-      "groupName": "ktor",
-      "matchPackageNames": [
-        "io.ktor:**"
       ]
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -10,26 +10,11 @@
   "packageRules": [
     {
       "matchUpdateTypes": [
+        "minor",
         "patch",
         "digest"
       ],
       "matchCurrentVersion": "!/^0/",
-      "automerge": true
-    },
-    {
-      "matchUpdateTypes": [
-        "minor"
-      ],
-      "matchCurrentVersion": "!/^0/",
-      "matchPackageNames": [
-        "io.kotest:**",
-        "de.mannodermaus.android-junit",
-        "io.mockk:**",
-        "app.cash.turbine:**",
-        "com.google.dagger:**",
-        "com.google.dagger.hilt.android",
-        "org.jetbrains.kotlinx:kotlinx-coroutines-**"
-      ],
       "automerge": true
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -71,6 +71,12 @@
       ]
     },
     {
+      "groupName": "github-actions",
+      "matchManagers": [
+        "github-actions"
+      ]
+    },
+    {
       "groupName": "static-analysis",
       "matchPackageNames": [
         "dev.detekt:**",

--- a/renovate.json
+++ b/renovate.json
@@ -7,22 +7,85 @@
     ":configMigration"
   ],
   "ignoreDeps": [
-    "io.github.lemkinator:common-utils"
+    "io.github.lemkinator:common-utils",
+    "io.github.tribalfs:oneui-design"
   ],
   "packageRules": [
     {
       "matchUpdateTypes": [
-        "minor",
         "patch",
         "digest"
       ],
       "matchCurrentVersion": "!/^0/",
+      "automerge": true,
+      "automergeType": "branch",
+      "platformAutomerge": true
+    },
+    {
+      "matchUpdateTypes": [
+        "minor"
+      ],
+      "matchCurrentVersion": "!/^0/",
+      "matchPackageNames": [
+        "io.kotest:**",
+        "io.mockk:**",
+        "app.cash.turbine:**",
+        "com.google.dagger:**",
+        "io.ktor:**",
+        "org.jetbrains.kotlinx:kotlinx-coroutines-test"
+      ],
       "automerge": true
+    },
+    {
+      "groupName": "kotlin",
+      "matchPackageNames": [
+        "org.jetbrains.kotlin:**",
+        "org.jetbrains.kotlin.android",
+        "com.google.devtools.ksp**"
+      ]
     },
     {
       "groupName": "hilt",
       "matchPackageNames": [
-        "com.google.dagger**"
+        "com.google.dagger:**",
+        "com.google.dagger.hilt.android"
+      ]
+    },
+    {
+      "groupName": "androidx-test",
+      "matchPackageNames": [
+        "androidx.test:**",
+        "androidx.test.ext:**",
+        "androidx.test.espresso:**"
+      ]
+    },
+    {
+      "groupName": "kotest",
+      "matchPackageNames": [
+        "io.kotest:**",
+        "de.mannodermaus.android-junit"
+      ]
+    },
+    {
+      "groupName": "ktor",
+      "matchPackageNames": [
+        "io.ktor:**"
+      ]
+    },
+    {
+      "groupName": "screenshot-testing",
+      "matchPackageNames": [
+        "io.github.takahirom.roborazzi:**",
+        "io.github.takahirom.roborazzi",
+        "org.robolectric:**"
+      ]
+    },
+    {
+      "groupName": "static-analysis",
+      "matchPackageNames": [
+        "dev.detekt:**",
+        "io.gitlab.arturbosch.detekt**",
+        "com.diffplug.spotless"
       ]
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -6,10 +6,7 @@
     ":renovatePrefix",
     ":configMigration"
   ],
-  "ignoreDeps": [
-    "io.github.lemkinator:common-utils",
-    "io.github.tribalfs:oneui-design"
-  ],
+  "platformAutomerge": true,
   "packageRules": [
     {
       "matchUpdateTypes": [
@@ -17,9 +14,7 @@
         "digest"
       ],
       "matchCurrentVersion": "!/^0/",
-      "automerge": true,
-      "automergeType": "branch",
-      "platformAutomerge": true
+      "automerge": true
     },
     {
       "matchUpdateTypes": [
@@ -28,11 +23,13 @@
       "matchCurrentVersion": "!/^0/",
       "matchPackageNames": [
         "io.kotest:**",
+        "de.mannodermaus.android-junit",
         "io.mockk:**",
         "app.cash.turbine:**",
         "com.google.dagger:**",
+        "com.google.dagger.hilt.android",
         "io.ktor:**",
-        "org.jetbrains.kotlinx:kotlinx-coroutines-test"
+        "org.jetbrains.kotlinx:kotlinx-coroutines-**"
       ],
       "automerge": true
     },


### PR DESCRIPTION
## Summary

- **renovate.json**: expand from minimal config to full package-grouped policy — adds `kotlin`, `androidx-test`, `kotest`, `ktor`, `screenshot-testing`, `static-analysis` groups; tightens minor automerge to safe packages only (patch+digest still automerge for all); adds `oneui-design` to `ignoreDeps`
- **CLAUDE.md**: new _Version Policy_ section documenting the lockstep rules (Kotlin/KSP), known exception classes, and the manual `lintDebug`-before-push reminder

## Test Plan

- [ ] Renovate opens grouped PRs within 24h of merge
- [ ] No existing functionality affected (config-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to use latest artifact upload tooling for improved reliability.
  * Enhanced automated dependency management with platform-wide automerging and refined update grouping rules.
  * Updated development documentation with dependency management guidelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lemkinator/GetIcon/pull/133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->