### PR TITLE
ci: add Codecov coverage upload and badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,16 +78,22 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
       - name: Run unit tests
-        run: chmod +x ./gradlew && ./gradlew testDebugUnitTest koverHtmlReportDebug koverVerifyDebug --stacktrace
+        run: chmod +x ./gradlew && ./gradlew testDebugUnitTest koverXmlReportDebug koverHtmlReportDebug koverVerifyDebug --stacktrace
         env:
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
           GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: app/build/reports/kover/reportDebug.xml
+          flags: unittests
+          fail_ci_if_error: true
       - name: Upload coverage report on failure
         if: failure()
         uses: actions/upload-artifact@v7
         with:
           name: kover-coverage-report
-          path: app/build/reports/kover/html/
+          path: app/build/reports/kover/htmlDebug/
 
   screenshot-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,6 @@ jobs:
         with:
           files: app/build/reports/kover/reportDebug.xml
           flags: unittests
-          fail_ci_if_error: true
       - name: Upload coverage report on failure
         if: failure()
         uses: actions/upload-artifact@v7

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ src='https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web
 
 [![Website](https://img.shields.io/website?down_color=red&down_message=offline&up_color=blue&up_message=online&url=https%3A%2F%2Fwww.leonard-lemke.com)](https://www.leonard-lemke.com/rr)
 [![Release](https://badgen.net/github/release/Lemkinator/GetIcon)](https://github.com/Lemkinator/GetIcon/releases)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![License](https://badgen.net/badge/license/Apache%202.0/blue)](https://opensource.org/licenses/Apache-2.0)
 [![API Level](https://badgen.net/badge/API/26%2B/green)](https://android-arsenal.com/api?level=26)
 [![Kotlin](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2FLemkinator%2FGetIcon%2Fmain%2Fgradle%2Flibs.versions.toml&query=%24.versions.kotlin&label=kotlin&color=7F52FF&logo=kotlin)](https://kotlinlang.org/)
 [![Last Commit](https://badgen.net/github/last-commit/Lemkinator/GetIcon)](https://github.com/Lemkinator/GetIcon/commits/)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ src='https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web
 [![Repo Size](https://img.shields.io/github/repo-size/Lemkinator/GetIcon)](https://github.com/Lemkinator/GetIcon)
 [![Lines of Code](https://sloc.xyz/github/Lemkinator/GetIcon)](https://github.com/Lemkinator/GetIcon)
 [![CodeFactor](https://www.codefactor.io/repository/github/lemkinator/geticon/badge)](https://www.codefactor.io/repository/github/lemkinator/geticon)
-[![codecov](https://codecov.io/github/Lemkinator/GetIcon/graph/badge.svg)](https://app.codecov.io/github/Lemkinator/GetIcon)
+[![codecov](https://codecov.io/gh/Lemkinator/GetIcon/graph/badge.svg)](https://codecov.io/gh/Lemkinator/GetIcon)
 
 # Get Icon
 

--- a/README.md
+++ b/README.md
@@ -11,15 +11,17 @@ src='https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web
 
 [![Website](https://img.shields.io/website?down_color=red&down_message=offline&up_color=blue&up_message=online&url=https%3A%2F%2Fwww.leonard-lemke.com)](https://www.leonard-lemke.com/rr)
 [![Release](https://badgen.net/github/release/Lemkinator/GetIcon)](https://github.com/Lemkinator/GetIcon/releases)
-[![API Level](https://img.shields.io/badge/API-26%2B-brightgreen.svg)](https://android-arsenal.com/api?level=26)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![API Level](https://badgen.net/badge/API/26%2B/green)](https://android-arsenal.com/api?level=26)
 [![Kotlin](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2FLemkinator%2FGetIcon%2Fmain%2Fgradle%2Flibs.versions.toml&query=%24.versions.kotlin&label=kotlin&color=7F52FF&logo=kotlin)](https://kotlinlang.org/)
 [![Last Commit](https://badgen.net/github/last-commit/Lemkinator/GetIcon)](https://github.com/Lemkinator/GetIcon/commits/)
-[![Issues](https://img.shields.io/github/issues-raw/Lemkinator/GetIcon?color=%23ff4400)](https://github.com/Lemkinator/GetIcon/issues)
-[![Pull Requests](https://img.shields.io/github/issues-pr-raw/Lemkinator/GetIcon?color=%23bb00bb)](https://github.com/Lemkinator/GetIcon/pulls)
-[![Contributors](https://img.shields.io/github/contributors/Lemkinator/GetIcon)](https://github.com/Lemkinator/GetIcon/graphs/contributors)
+[![Issues](https://badgen.net/github/open-issues/Lemkinator/GetIcon)](https://github.com/Lemkinator/GetIcon/issues)
+[![Pull Requests](https://badgen.net/github/open-prs/Lemkinator/GetIcon)](https://github.com/Lemkinator/GetIcon/pulls)
+[![Contributors](https://badgen.net/github/contributors/Lemkinator/GetIcon)](https://github.com/Lemkinator/GetIcon/graphs/contributors)
 [![Repo Size](https://img.shields.io/github/repo-size/Lemkinator/GetIcon)](https://github.com/Lemkinator/GetIcon)
 [![Lines of Code](https://sloc.xyz/github/Lemkinator/GetIcon)](https://github.com/Lemkinator/GetIcon)
 [![CodeFactor](https://www.codefactor.io/repository/github/lemkinator/geticon/badge)](https://www.codefactor.io/repository/github/lemkinator/geticon)
+[![codecov](https://codecov.io/github/Lemkinator/GetIcon/graph/badge.svg)](https://app.codecov.io/github/Lemkinator/GetIcon)
 
 # Get Icon
 


### PR DESCRIPTION
## Summary
- Adds `koverXmlReportDebug` to the unit-tests CI job and uploads the report to Codecov
- Codecov upload is non-blocking (failures are ignored so Codecov downtime can't break CI)
- Fixes HTML artifact upload path: `html/` → `htmlDebug/` (correct Kover 0.9.x output path)
- Adds Codecov badge and license badge to README; converts remaining shields.io GitHub-data badges to badgen.net

## Test plan
- [ ] Verify Codecov upload step succeeds in CI
- [ ] Confirm badge appears at https://app.codecov.io/github/Lemkinator/GetIcon

🤖 Generated with [Claude Code](https://claude.com/claude-code)