### PR TITLE
chore: adopt NIA-model Gradle JVM config + CI parallelism bounds

### DIFF
--- a/.github/ci-gradle.properties
+++ b/.github/ci-gradle.properties
@@ -1,0 +1,7 @@
+org.gradle.daemon=false
+org.gradle.parallel=true
+org.gradle.workers.max=2
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.parallel=true
+
+kotlin.incremental=false

--- a/.github/ci-gradle.properties
+++ b/.github/ci-gradle.properties
@@ -1,7 +1,4 @@
 org.gradle.daemon=false
-org.gradle.parallel=true
 org.gradle.workers.max=2
-org.gradle.configuration-cache=true
-org.gradle.configuration-cache.parallel=true
 
 kotlin.incremental=false

--- a/.github/ci-gradle.properties
+++ b/.github/ci-gradle.properties
@@ -1,4 +1,7 @@
 org.gradle.daemon=false
+org.gradle.parallel=true
 org.gradle.workers.max=2
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.parallel=true
 
 kotlin.incremental=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
@@ -44,6 +46,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
@@ -70,6 +74,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
@@ -107,6 +113,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
@@ -133,6 +141,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
@@ -159,6 +169,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,14 +16,14 @@
 # - CodeCache normally defaults to a very small size. Increasing it from platform defaults of 32-48m
 #   because of how many classes can be loaded into memory and then cached as native compiled code
 #   for a small speed boost.
-org.gradle.jvmargs=-Dfile.encoding=UTF-8 -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:ReservedCodeCacheSize=256m -XX:+HeapDumpOnOutOfMemoryError -Xmx4g -Xms4g
+org.gradle.jvmargs=-Dfile.encoding=UTF-8 -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:ReservedCodeCacheSize=256m -XX:+HeapDumpOnOutOfMemoryError -Xmx4g
 
 # For more information about how Kotlin Daemon memory options were chosen:
 # - Kotlin JVM args only inherit Xmx, ReservedCodeCache, and MaxMetaspace. Since we are specifying
 #   other args we need to specify all of them here.
 # - We're using the Kotlin Gradle Plugin's default value for ReservedCodeCacheSize, if we do not then
 #   the Gradle JVM arg value for ReservedCodeCacheSize will be used.
-kotlin.daemon.jvmargs=-Dfile.encoding=UTF-8 -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:ReservedCodeCacheSize=320m -XX:+HeapDumpOnOutOfMemoryError -Xmx4g -Xms4g
+kotlin.daemon.jvmargs=-Dfile.encoding=UTF-8 -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:ReservedCodeCacheSize=320m -XX:+HeapDumpOnOutOfMemoryError -Xmx4g
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,14 +16,14 @@
 # - CodeCache normally defaults to a very small size. Increasing it from platform defaults of 32-48m
 #   because of how many classes can be loaded into memory and then cached as native compiled code
 #   for a small speed boost.
-org.gradle.jvmargs=-Dfile.encoding=UTF-8 -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:ReservedCodeCacheSize=256m -XX:+HeapDumpOnOutOfMemoryError -Xmx4g
+org.gradle.jvmargs=-Dfile.encoding=UTF-8 -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:ReservedCodeCacheSize=256m -XX:+HeapDumpOnOutOfMemoryError -Xmx4g -Xms4g
 
 # For more information about how Kotlin Daemon memory options were chosen:
 # - Kotlin JVM args only inherit Xmx, ReservedCodeCache, and MaxMetaspace. Since we are specifying
 #   other args we need to specify all of them here.
 # - We're using the Kotlin Gradle Plugin's default value for ReservedCodeCacheSize, if we do not then
 #   the Gradle JVM arg value for ReservedCodeCacheSize will be used.
-kotlin.daemon.jvmargs=-Dfile.encoding=UTF-8 -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:ReservedCodeCacheSize=320m -XX:+HeapDumpOnOutOfMemoryError -Xmx4g
+kotlin.daemon.jvmargs=-Dfile.encoding=UTF-8 -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:ReservedCodeCacheSize=320m -XX:+HeapDumpOnOutOfMemoryError -Xmx4g -Xms4g
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,11 +6,32 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+# Ensure important default jvmargs aren't overwritten. See https://github.com/gradle/gradle/issues/19750
+#
+# For more information about how Gradle memory options were chosen:
+# - Metaspace See https://www.jasonpearson.dev/metaspace-in-jvm-builds/
+# - SoftRefLRUPolicyMSPerMB would default to 1000 which with a 4gb heap translates to ~51 minutes.
+#   A value of 1 means ~4 seconds before SoftRefs can be collected, which means its realistic to
+#   collect them as needed during a build that should take seconds to minutes.
+# - CodeCache normally defaults to a very small size. Increasing it from platform defaults of 32-48m
+#   because of how many classes can be loaded into memory and then cached as native compiled code
+#   for a small speed boost.
+org.gradle.jvmargs=-Dfile.encoding=UTF-8 -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:ReservedCodeCacheSize=256m -XX:+HeapDumpOnOutOfMemoryError -Xmx4g -Xms4g
+
+# For more information about how Kotlin Daemon memory options were chosen:
+# - Kotlin JVM args only inherit Xmx, ReservedCodeCache, and MaxMetaspace. Since we are specifying
+#   other args we need to specify all of them here.
+# - We're using the Kotlin Gradle Plugin's default value for ReservedCodeCacheSize, if we do not then
+#   the Gradle JVM arg value for ReservedCodeCacheSize will be used.
+kotlin.daemon.jvmargs=-Dfile.encoding=UTF-8 -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:ReservedCodeCacheSize=320m -XX:+HeapDumpOnOutOfMemoryError -Xmx4g -Xms4g
+
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+org.gradle.parallel=true
+
+# Enable caching between builds.
+org.gradle.caching=true
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
@@ -21,6 +42,7 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+# Enable configuration caching between builds.
 org.gradle.configuration-cache=true
-#org.gradle.configuration-cache.problems=warn
+org.gradle.configuration-cache.parallel=true
 android.uniquePackageNames=false


### PR DESCRIPTION
## Summary

- Raise Gradle daemon heap from 2048m → 4g; add G1GC, `SoftRefLRUPolicyMSPerMB=1`, `ReservedCodeCacheSize=256m`, `HeapDumpOnOutOfMemoryError` — OOMs now produce a `.hprof` instead of a silent hang
- Add matching `kotlin.daemon.jvmargs` (320m code cache per KGP default)
- Enable `org.gradle.parallel`, `org.gradle.caching`, and `org.gradle.configuration-cache.parallel`
- Add `.github/ci-gradle.properties` (`daemon=false`, `workers.max=2`, `kotlin.incremental=false`) and wire it into every CI job via a "Copy CI gradle.properties" step — without the copy step `workers.max=2` is silently ignored

## Test plan

- [x] `./gradlew spotlessCheck detekt lintDebug testDebugUnitTest koverVerifyDebug verifyRoborazziDebug` — green (2m 39s)
- [x] `./gradlew pixel9Api35DebugAndroidTest` — 3/3 passed (1m 23s)
- [x] No configuration-cache serialization warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Gradle and Kotlin JVM Configuration Modernization

Updated Gradle and Kotlin compiler JVM configuration to improve memory management and diagnostics:

**gradle.properties:**
- Increased Gradle daemon heap from 2GB to 4GB with G1GC
- Added JVM flags: `SoftRefLRUPolicyMSPerMB=1`, `ReservedCodeCacheSize=256m`, `HeapDumpOnOutOfMemoryError`
- Updated `kotlin.daemon.jvmargs` with matching 320MB code cache
- Enabled build parallelization: `org.gradle.parallel`, `org.gradle.caching`, `org.gradle.configuration-cache.parallel`

**New CI configuration:**
- Added `.github/ci-gradle.properties` with CI-specific settings (`daemon=false`, `workers.max=2`, `kotlin.incremental=false`)
- Updated `.github/workflows/ci.yml` to copy CI properties file to `~/.gradle/gradle.properties` before build steps across all CI jobs

All build checks and tests pass with no configuration-cache warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->