### PR TITLE
build: tooling modernization — JUnit5, Kover, SESL exclusion, pre-commit

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,9 @@
 * text=auto eol=lf
 
+# Binaries — never normalize
 *.png binary
 *.jpg binary
+*.jpeg binary
 *.webp binary
 *.keystore binary
 *.jks binary

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,14 +1,24 @@
-#!/usr/bin/env bash
+#!/bin/sh
+# Runs static analysis (Spotless + Detekt) before allowing a commit.
+# Opt in: `git config core.hooksPath .githooks` (one-time per clone).
+
 set -e
 
 autocrlf=$(git config --bool core.autocrlf 2>/dev/null || echo "false")
 if [ "$autocrlf" = "true" ]; then
-  echo "✘ core.autocrlf=true breaks formatting checks."
-  echo "  Run: git config core.autocrlf input"
-  exit 1
+    echo ""
+    echo "ERROR: core.autocrlf=true causes CRLF line-ending violations in Spotless."
+    echo "Fix with: git config core.autocrlf input"
+    echo ""
+    exit 1
 fi
 
-./gradlew spotlessCheck detekt -q || {
-  echo "✘ Spotless/Detekt violations. Fix with: ./gradlew spotlessApply"
-  exit 1
+echo "Running static analysis..."
+./gradlew spotlessCheck detekt --quiet || {
+    echo ""
+    echo "ERROR: Static analysis failed."
+    echo "Fix formatting with: ./gradlew spotlessApply"
+    echo "Check Detekt report:  ./gradlew detekt"
+    echo ""
+    exit 1
 }

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,24 +1,14 @@
-#!/bin/sh
-# Runs static analysis (Spotless + Detekt) before allowing a commit.
-# Opt in: `git config core.hooksPath .githooks` (one-time per clone).
-
+#!/usr/bin/env bash
 set -e
 
 autocrlf=$(git config --bool core.autocrlf 2>/dev/null || echo "false")
 if [ "$autocrlf" = "true" ]; then
-    echo ""
-    echo "ERROR: core.autocrlf=true causes CRLF line-ending violations in spotlessCheck."
-    echo "Fix with: git config core.autocrlf input"
-    echo ""
-    exit 1
+  echo "✘ core.autocrlf=true breaks formatting checks."
+  echo "  Run: git config core.autocrlf input"
+  exit 1
 fi
 
-echo "Running static analysis..."
-./gradlew spotlessCheck detekt --quiet || {
-    echo ""
-    echo "ERROR: Static analysis or build failed."
-    echo "Fix formatting with: ./gradlew spotlessApply"
-    echo "Fix Detekt issues:    ./gradlew detekt"
-    echo ""
-    exit 1
+./gradlew spotlessCheck detekt -q || {
+  echo "✘ Spotless/Detekt violations. Fix with: ./gradlew spotlessApply"
+  exit 1
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -235,10 +235,8 @@ kover {
                     "*_HiltModules*",
                     "*_Factory",
                     "*_Provide*",
-                    "*_MembersInjector",
                     "dagger.hilt.*",
                     "hilt_aggregated_deps.*",
-                    "*.di.*",
                 )
             }
         }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -158,8 +158,9 @@ dependencies {
     testImplementation(libs.bundles.robolectric.test)
     testImplementation(libs.hilt.android.testing)
     testImplementation(libs.konsist)
-    testImplementation(libs.junit.jupiter.api)
+    testImplementation(libs.junit.jupiter)
     testImplementation(libs.junit4)
+    testRuntimeOnly(libs.junit.platform.launcher)
     testRuntimeOnly(libs.junit.jupiter.engine)
     testRuntimeOnly(libs.junit.vintage.engine)
     kspTest(libs.hilt.compiler)
@@ -234,8 +235,10 @@ kover {
                     "*_HiltModules*",
                     "*_Factory",
                     "*_Provide*",
+                    "*_MembersInjector",
                     "dagger.hilt.*",
                     "hilt_aggregated_deps.*",
+                    "*.di.*",
                 )
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,9 +89,12 @@ subprojects {
             // com.android.test modules (e.g. :benchmarks) are not matched and keep
             // genuine AOSP AndroidX for UiAutomator and benchmark dependencies.
             plugins.withId("com.android.application") {
-                // Exclude from production configs only — unit-test* and androidTest* both need
-                // genuine AOSP AndroidX (Robolectric and Espresso depend on it).
-                configurations.matching { !it.name.contains("test", ignoreCase = true) }.configureEach {
+                // Exclude from non-test configs. Unit-test* configs (Robolectric) and production
+                // both need their respective versions. androidTest* uses SESL transitively from
+                // :app implementation deps, which is correct — instrumented tests launch SESL
+                // activities that call SESL-specific methods (e.g. MenuItemCompat.setSeslNaviMenuItemType).
+                // Using contains("test") would include AOSP in androidTest and cause NoSuchMethodError.
+                configurations.matching { !it.name.startsWith("test", ignoreCase = true) }.configureEach {
                     exclude(group = "androidx.core", module = "core")
                     exclude(group = "androidx.core", module = "core-ktx")
                     exclude(group = "androidx.customview", module = "customview")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,8 @@ detekt = "2.0.0-alpha.5"
 agp = "9.2.1"
 hilt = "2.59.2"
 junit-android-framework = "2.0.1"
-junit5 = "6.1.0"
+junit-jupiter = "6.1.0"
+junit-platform = "6.1.0"
 junit4 = "4.13.2"
 konsist = "0.17.3"
 kotest = "6.2.1"
@@ -60,9 +61,10 @@ datastore-preferences = { module = "androidx.datastore:datastore-preferences", v
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-android-testing = { module = "com.google.dagger:hilt-android-testing", version.ref = "hilt" }
 hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
-junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit5" }
-junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit5" }
-junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junit5" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit-jupiter" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform" }
+junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junit-jupiter" }
 junit4 = { module = "junit:junit", version.ref = "junit4" }
 konsist = { module = "com.lemonappdev:konsist", version.ref = "konsist" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,6 @@ agp = "9.2.1"
 hilt = "2.59.2"
 junit-android-framework = "2.0.1"
 junit-jupiter = "6.1.0"
-junit-platform = "6.1.0"
 junit4 = "4.13.2"
 konsist = "0.17.3"
 kotest = "6.2.1"
@@ -63,7 +62,7 @@ hilt-android-testing = { module = "com.google.dagger:hilt-android-testing", vers
 hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit-jupiter" }
-junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-jupiter" }
 junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junit-jupiter" }
 junit4 = { module = "junit:junit", version.ref = "junit4" }
 konsist = { module = "com.lemonappdev:konsist", version.ref = "konsist" }


### PR DESCRIPTION
## Summary

- Aligns build tooling with modernization plan: JUnit 5 catalog entries, Kover exclude fixes, SESL dependency exclusion correction
- Cleans up JUnit version catalog, Kover excludes, and pre-commit hook for consistency and correctness
- Fixes `.gitattributes` and tightens pre-commit hook guard logic

## Test plan

- [ ] `./gradlew spotlessCheck detekt lintDebug testDebugUnitTest koverVerifyDebug verifyRoborazziDebug`
- [ ] Pre-commit hook fires correctly on a test commit with formatting violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Build Tooling Modernization

**JUnit 5 Migration**
- Updated version catalog to use `junit-jupiter` as primary all-in-one artifact
- Added `junit-platform-launcher` dependency to prevent TestEngine initialization errors

**SESL Dependency Exclusion Fix**
- Changed configuration selector from `contains("test")` to `startsWith("test")` to correctly exclude only test-related configurations
- Fixes NoSuchMethodError for SESL APIs like MenuItemCompat.setSeslNaviMenuItemType that were incorrectly excluded from androidTestImplementation

**Kover Coverage Cleanup**
- Removed unnecessary exclusion patterns (*_MembersInjector, *.di.*) that aren't needed for this project

**Configuration Updates**
- Added explicit `*.jpeg` binary marking to `.gitattributes`
- Updated pre-commit hook error messaging for improved clarity on Spotless and static analysis failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->