### PR TITLE
fix: toast on load failure, safe fallback NPE, remove trivial comments

### DIFF
--- a/app/src/main/java/de/lemke/geticon/data/UserSettingsRepository.kt
+++ b/app/src/main/java/de/lemke/geticon/data/UserSettingsRepository.kt
@@ -80,17 +80,11 @@ class UserSettingsRepository @Inject constructor(
     }
 }
 
-/** Settings associated with the current user. */
 data class UserSettings(
-    /** icon Size*/
     val iconSize: Int,
-    /** mask enabled*/
     val maskEnabled: Boolean,
-    /** color enabled*/
     val colorEnabled: Boolean,
-    /** recent background colors */
     val recentBackgroundColors: List<Int>,
-    /** recent foreground colors */
     val recentForegroundColors: List<Int>,
 ) {
     companion object {

--- a/app/src/main/java/de/lemke/geticon/domain/GenerateIconUseCase.kt
+++ b/app/src/main/java/de/lemke/geticon/domain/GenerateIconUseCase.kt
@@ -56,7 +56,12 @@ class GenerateIconUseCase @Inject constructor(
             try {
                 applicationInfo.loadIcon(packageManager)
             } catch (_: Exception) {
-                AppCompatResources.getDrawable(context, dev.oneuiproject.oneui.R.drawable.ic_oui_file_type_image)!!
+                AppCompatResources.getDrawable(context, dev.oneuiproject.oneui.R.drawable.ic_oui_file_type_image)
+                    ?: return IconResult(
+                        bitmap = createBitmap(size, size),
+                        isAdaptiveIcon = false,
+                        hasMaskedAppIcon = false,
+                    )
             }
         val maskedAppIcon = semGetApplicationIconForIconTray(packageManager, applicationInfo.packageName, 1)
         val isAdaptiveIcon = appIcon is AdaptiveIconDrawable

--- a/app/src/main/java/de/lemke/geticon/domain/GenerateIconUseCase.kt
+++ b/app/src/main/java/de/lemke/geticon/domain/GenerateIconUseCase.kt
@@ -42,6 +42,11 @@ data class IconResult(
 class GenerateIconUseCase @Inject constructor(
     @param:ApplicationContext private val context: Context,
 ) {
+    /**
+     * Loads an app icon and renders it into a bitmap, optionally applying masking and color tinting.
+     *
+     * @return An [IconResult] containing the rendered bitmap and metadata about the icon type.
+     */
     @SuppressLint("RestrictedApi")
     operator fun invoke(
         applicationInfo: ApplicationInfo,

--- a/app/src/main/java/de/lemke/geticon/ui/MainActivity.kt
+++ b/app/src/main/java/de/lemke/geticon/ui/MainActivity.kt
@@ -204,6 +204,11 @@ class MainActivity :
         lifecycleScope.launch { loadPackageList() }
     }
 
+    /**
+     * Loads the list of installed apps and displays them in the app picker.
+     *
+     * If loading fails, displays an error message to the user.
+     */
     @Suppress("TooGenericExceptionCaught")
     private suspend fun loadPackageList() {
         try {

--- a/app/src/main/java/de/lemke/geticon/ui/MainActivity.kt
+++ b/app/src/main/java/de/lemke/geticon/ui/MainActivity.kt
@@ -217,6 +217,7 @@ class MainActivity :
         } catch (e: Exception) {
             if (e is CancellationException) throw e
             Log.e("MainActivity", "Failed to load package list", e)
+            toast(commonutilsR.string.commonutils_error)
         }
     }
 

--- a/app/src/test/java/de/lemke/geticon/domain/GenerateIconUseCaseTest.kt
+++ b/app/src/test/java/de/lemke/geticon/domain/GenerateIconUseCaseTest.kt
@@ -23,6 +23,7 @@ import android.graphics.Color
 import android.graphics.drawable.AdaptiveIconDrawable
 import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.reflect.app.SeslApplicationPackageManagerReflector
 import androidx.test.core.app.ApplicationProvider
 import de.lemke.geticon.App
@@ -261,5 +262,25 @@ class GenerateIconUseCaseTest {
                 }
             val result = useCase(badAppInfo, 128, maskEnabled = false, colorEnabled = false, 0, 0, packageManager)
             result.bitmap shouldNotBe null
+        }
+
+    @Test
+    fun `loadIcon failure with null fallback drawable returns blank IconResult of requested size`() =
+        runTest {
+            mockkStatic(AppCompatResources::class)
+            try {
+                every { AppCompatResources.getDrawable(any(), any()) } returns null
+                val badAppInfo =
+                    object : ApplicationInfo() {
+                        override fun loadIcon(pm: PackageManager) = throw IllegalStateException("forced failure")
+                    }.apply { packageName = "com.does.not.exist" }
+                val result = useCase(badAppInfo, 128, maskEnabled = false, colorEnabled = false, 0, 0, packageManager)
+                result.bitmap.width shouldBe 128
+                result.bitmap.height shouldBe 128
+                result.isAdaptiveIcon shouldBe false
+                result.hasMaskedAppIcon shouldBe false
+            } finally {
+                unmockkStatic(AppCompatResources::class)
+            }
         }
 }


### PR DESCRIPTION
## Summary

- **`MainActivity`**: show `commonutils_error` toast when `loadPackageList` throws, so users see feedback instead of a silent blank list
- **`GenerateIconUseCase`**: replace `!!` with `?: return IconResult(...)` on the `AppCompatResources.getDrawable` fallback path — avoids NPE if the drawable is missing in an unusual build variant
- **`UserSettingsRepository`**: remove trivial KDoc comments on `UserSettings` properties that just restate the property names (CLAUDE.md: no comments when the what is obvious)
- **`GenerateIconUseCaseTest`**: add test covering the new null-drawable branch to restore 100% Kover coverage

## Test plan

- [ ] Full CI suite passes: `spotlessCheck detekt lintDebug testDebugUnitTest koverVerifyDebug verifyRoborazziDebug`
- [ ] New test `loadIcon failure with null fallback drawable returns blank IconResult of requested size` covers the `?: return` branch
- [ ] Manual: trigger APK load failure on device and confirm error toast appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Code Quality and UX Improvements

- **MainActivity**: Shows a user-facing error toast (`commonutils_error`) when `loadPackageList()` fails (still rethrows `CancellationException`), avoiding a blank list with silent failures.
- **GenerateIconUseCase**: Removes unsafe `!!` when loading the fallback drawable; if the drawable is `null`, returns a blank `IconResult` of the requested size (`isAdaptiveIcon=false`, `hasMaskedAppIcon=false`) to prevent potential NPEs.
- **UserSettingsRepository**: Removes redundant KDoc comments that restate property names.
- **GenerateIconUseCaseTest**: Adds a test for the null fallback drawable path (mocking `AppCompatResources.getDrawable`), restoring full Kover coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->