### PR TITLE
refactor: use onView(isRoot()) in screenshot tests

### DIFF
--- a/app/src/test/java/de/lemke/geticon/TestUtils.kt
+++ b/app/src/test/java/de/lemke/geticon/TestUtils.kt
@@ -18,8 +18,10 @@ package de.lemke.geticon
 
 import de.lemke.commonutils.data.SettingsRepository
 
-// Sets lastVersionCode and acceptedTosVersion to Int.MAX_VALUE so onboardIfNeeded()
-// never redirects to OOBE in tests — no real version code will ever reach MAX_VALUE.
+/**
+ * Sets lastVersionCode and acceptedTosVersion to Int.MAX_VALUE so onboardIfNeeded()
+ * never redirects to OOBE in tests — no real version code will ever reach MAX_VALUE.
+ */
 fun SettingsRepository.bypassOobe() {
     lastVersionCode = Int.MAX_VALUE
     acceptedTosVersion = Int.MAX_VALUE

--- a/app/src/test/java/de/lemke/geticon/TestUtils.kt
+++ b/app/src/test/java/de/lemke/geticon/TestUtils.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022-2026 Leonard Lemke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.lemke.geticon
+
+import de.lemke.commonutils.data.SettingsRepository
+
+// Sets lastVersionCode and acceptedTosVersion to Int.MAX_VALUE so onboardIfNeeded()
+// never redirects to OOBE in tests — no real version code will ever reach MAX_VALUE.
+fun SettingsRepository.bypassOobe() {
+    lastVersionCode = Int.MAX_VALUE
+    acceptedTosVersion = Int.MAX_VALUE
+}

--- a/app/src/test/java/de/lemke/geticon/ui/IconActivityScreenshotTest.kt
+++ b/app/src/test/java/de/lemke/geticon/ui/IconActivityScreenshotTest.kt
@@ -17,9 +17,10 @@
 package de.lemke.geticon.ui
 
 import android.content.Intent
-import android.os.Looper
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import com.github.takahirom.roborazzi.captureRoboImage
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
@@ -37,7 +38,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
 
@@ -90,11 +90,8 @@ class IconActivityScreenshotTest {
         val context = ApplicationProvider.getApplicationContext<HiltTestApplication>()
         val appInfo = context.packageManager.getApplicationInfo(context.packageName, 0)
         val intent = Intent(context, IconActivity::class.java).putExtra(IconActivity.KEY_APPLICATION_INFO, appInfo)
-        ActivityScenario.launch<IconActivity>(intent).use { scenario ->
-            shadowOf(Looper.getMainLooper()).idle()
-            scenario.onActivity { activity ->
-                activity.window.decorView.captureRoboImage(fileName)
-            }
+        ActivityScenario.launch<IconActivity>(intent).use {
+            onView(isRoot()).captureRoboImage(fileName)
         }
     }
 

--- a/app/src/test/java/de/lemke/geticon/ui/MainActivityScreenshotTest.kt
+++ b/app/src/test/java/de/lemke/geticon/ui/MainActivityScreenshotTest.kt
@@ -29,8 +29,9 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import com.github.takahirom.roborazzi.captureRoboImage
+import dagger.hilt.android.testing.HiltTestApplication
 import de.lemke.commonutils.data.commonUtilsSettings
-import de.lemke.geticon.App
+import de.lemke.commonutils.data.initCommonUtilsSettingsAndSetDarkMode
 import java.net.URL
 import org.junit.Before
 import org.junit.Test
@@ -41,14 +42,13 @@ import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
 
 // sdk = [36]: Robolectric 4.16.1 max supported SDK; bump when 4.17+ adds SDK 37.
-// App::class: uses the production Hilt component so App.onCreate() initializes commonUtilsSettings.
 @RunWith(RobolectricTestRunner::class)
-@Config(application = App::class, sdk = [36])
+@Config(application = HiltTestApplication::class, sdk = [36])
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 class MainActivityScreenshotTest {
     @Before
     fun setup() {
-        // Bypass OOBE: fresh test has lastVersionCode == -1 which triggers openOOBEAndFinish().
+        ApplicationProvider.getApplicationContext<HiltTestApplication>().initCommonUtilsSettingsAndSetDarkMode()
         commonUtilsSettings.lastVersionCode = Int.MAX_VALUE
         commonUtilsSettings.acceptedTosVersion = Int.MAX_VALUE
     }

--- a/app/src/test/java/de/lemke/geticon/ui/MainActivityScreenshotTest.kt
+++ b/app/src/test/java/de/lemke/geticon/ui/MainActivityScreenshotTest.kt
@@ -29,26 +29,33 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import com.github.takahirom.roborazzi.captureRoboImage
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.HiltTestApplication
 import de.lemke.commonutils.data.commonUtilsSettings
 import de.lemke.commonutils.data.initCommonUtilsSettingsAndSetDarkMode
 import de.lemke.geticon.bypassOobe
 import java.net.URL
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
 
 // sdk = [36]: Robolectric 4.16.1 max supported SDK; bump when 4.17+ adds SDK 37.
+@HiltAndroidTest
 @RunWith(RobolectricTestRunner::class)
 @Config(application = HiltTestApplication::class, sdk = [36])
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 class MainActivityScreenshotTest {
+    @get:Rule
+    val hiltRule = HiltAndroidRule(this)
+
     @Before
     fun setup() {
+        hiltRule.inject()
         ApplicationProvider.getApplicationContext<HiltTestApplication>().initCommonUtilsSettingsAndSetDarkMode()
         commonUtilsSettings.bypassOobe()
     }

--- a/app/src/test/java/de/lemke/geticon/ui/MainActivityScreenshotTest.kt
+++ b/app/src/test/java/de/lemke/geticon/ui/MainActivityScreenshotTest.kt
@@ -27,6 +27,8 @@ import android.graphics.drawable.BitmapDrawable
 import android.os.Looper
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import com.github.takahirom.roborazzi.captureRoboImage
 import de.lemke.commonutils.data.commonUtilsSettings
 import de.lemke.geticon.App
@@ -54,10 +56,8 @@ class MainActivityScreenshotTest {
 
     @Test
     fun mainActivity_default() {
-        ActivityScenario.launch(MainActivity::class.java).use { scenario ->
-            scenario.onActivity { activity ->
-                activity.window.decorView.captureRoboImage("src/test/screenshots/main_default.png")
-            }
+        ActivityScenario.launch(MainActivity::class.java).use {
+            onView(isRoot()).captureRoboImage("src/test/screenshots/main_default.png")
         }
     }
 
@@ -65,13 +65,11 @@ class MainActivityScreenshotTest {
     @Config(qualifiers = "+night")
     fun mainActivity_default_dark() {
         installFakeApps()
-        ActivityScenario.launch(MainActivity::class.java).use { scenario ->
+        ActivityScenario.launch(MainActivity::class.java).use {
             @Suppress("MagicNumber")
             Thread.sleep(500)
             shadowOf(Looper.getMainLooper()).idle()
-            scenario.onActivity { activity ->
-                activity.window.decorView.captureRoboImage("src/test/screenshots/main_default_dark.png")
-            }
+            onView(isRoot()).captureRoboImage("src/test/screenshots/main_default_dark.png")
         }
     }
 

--- a/app/src/test/java/de/lemke/geticon/ui/MainActivityScreenshotTest.kt
+++ b/app/src/test/java/de/lemke/geticon/ui/MainActivityScreenshotTest.kt
@@ -24,7 +24,6 @@ import android.content.pm.ApplicationInfo
 import android.content.pm.ResolveInfo
 import android.graphics.BitmapFactory
 import android.graphics.drawable.BitmapDrawable
-import android.os.Looper
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
@@ -68,7 +67,6 @@ class MainActivityScreenshotTest {
         ActivityScenario.launch(MainActivity::class.java).use {
             @Suppress("MagicNumber")
             Thread.sleep(500)
-            shadowOf(Looper.getMainLooper()).idle()
             onView(isRoot()).captureRoboImage("src/test/screenshots/main_default_dark.png")
         }
     }

--- a/app/src/test/java/de/lemke/geticon/ui/MainActivityScreenshotTest.kt
+++ b/app/src/test/java/de/lemke/geticon/ui/MainActivityScreenshotTest.kt
@@ -32,6 +32,7 @@ import com.github.takahirom.roborazzi.captureRoboImage
 import dagger.hilt.android.testing.HiltTestApplication
 import de.lemke.commonutils.data.commonUtilsSettings
 import de.lemke.commonutils.data.initCommonUtilsSettingsAndSetDarkMode
+import de.lemke.geticon.bypassOobe
 import java.net.URL
 import org.junit.Before
 import org.junit.Test
@@ -49,8 +50,7 @@ class MainActivityScreenshotTest {
     @Before
     fun setup() {
         ApplicationProvider.getApplicationContext<HiltTestApplication>().initCommonUtilsSettingsAndSetDarkMode()
-        commonUtilsSettings.lastVersionCode = Int.MAX_VALUE
-        commonUtilsSettings.acceptedTosVersion = Int.MAX_VALUE
+        commonUtilsSettings.bypassOobe()
     }
 
     @Test

--- a/app/src/test/java/de/lemke/geticon/ui/MainActivityScreenshotTest.kt
+++ b/app/src/test/java/de/lemke/geticon/ui/MainActivityScreenshotTest.kt
@@ -41,6 +41,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
 

--- a/app/src/test/java/de/lemke/geticon/ui/SettingsActivityScreenshotTest.kt
+++ b/app/src/test/java/de/lemke/geticon/ui/SettingsActivityScreenshotTest.kt
@@ -16,8 +16,9 @@
 
 package de.lemke.geticon.ui
 
-import android.os.Looper
 import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import com.github.takahirom.roborazzi.captureRoboImage
 import de.lemke.commonutils.data.commonUtilsSettings
 import de.lemke.commonutils.setupCommonUtilsSettingsActivity
@@ -27,7 +28,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
 import de.lemke.commonutils.R as commonutilsR
@@ -52,22 +52,16 @@ class SettingsActivityScreenshotTest {
 
     @Test
     fun settingsActivity_default() {
-        ActivityScenario.launch(CommonUtilsSettingsActivity::class.java).use { scenario ->
-            shadowOf(Looper.getMainLooper()).idle()
-            scenario.onActivity { activity ->
-                activity.window.decorView.captureRoboImage("src/test/screenshots/settings_default.png")
-            }
+        ActivityScenario.launch(CommonUtilsSettingsActivity::class.java).use {
+            onView(isRoot()).captureRoboImage("src/test/screenshots/settings_default.png")
         }
     }
 
     @Test
     @Config(qualifiers = "+night")
     fun settingsActivity_default_dark() {
-        ActivityScenario.launch(CommonUtilsSettingsActivity::class.java).use { scenario ->
-            shadowOf(Looper.getMainLooper()).idle()
-            scenario.onActivity { activity ->
-                activity.window.decorView.captureRoboImage("src/test/screenshots/settings_default_dark.png")
-            }
+        ActivityScenario.launch(CommonUtilsSettingsActivity::class.java).use {
+            onView(isRoot()).captureRoboImage("src/test/screenshots/settings_default_dark.png")
         }
     }
 }

--- a/app/src/test/java/de/lemke/geticon/ui/SettingsActivityScreenshotTest.kt
+++ b/app/src/test/java/de/lemke/geticon/ui/SettingsActivityScreenshotTest.kt
@@ -21,6 +21,8 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import com.github.takahirom.roborazzi.captureRoboImage
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.HiltTestApplication
 import de.lemke.commonutils.data.commonUtilsSettings
 import de.lemke.commonutils.data.initCommonUtilsSettingsAndSetDarkMode
@@ -28,6 +30,7 @@ import de.lemke.commonutils.setupCommonUtilsSettingsActivity
 import de.lemke.commonutils.ui.activity.CommonUtilsSettingsActivity
 import de.lemke.geticon.bypassOobe
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -36,12 +39,17 @@ import org.robolectric.annotation.GraphicsMode
 import de.lemke.commonutils.R as commonutilsR
 
 // sdk = [36]: Robolectric 4.16.1 max supported SDK; bump when 4.17+ adds SDK 37.
+@HiltAndroidTest
 @RunWith(RobolectricTestRunner::class)
 @Config(application = HiltTestApplication::class, sdk = [36])
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 class SettingsActivityScreenshotTest {
+    @get:Rule
+    val hiltRule = HiltAndroidRule(this)
+
     @Before
     fun setup() {
+        hiltRule.inject()
         ApplicationProvider.getApplicationContext<HiltTestApplication>().initCommonUtilsSettingsAndSetDarkMode()
         commonUtilsSettings.bypassOobe()
         setupCommonUtilsSettingsActivity(

--- a/app/src/test/java/de/lemke/geticon/ui/SettingsActivityScreenshotTest.kt
+++ b/app/src/test/java/de/lemke/geticon/ui/SettingsActivityScreenshotTest.kt
@@ -17,13 +17,15 @@
 package de.lemke.geticon.ui
 
 import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import com.github.takahirom.roborazzi.captureRoboImage
+import dagger.hilt.android.testing.HiltTestApplication
 import de.lemke.commonutils.data.commonUtilsSettings
+import de.lemke.commonutils.data.initCommonUtilsSettingsAndSetDarkMode
 import de.lemke.commonutils.setupCommonUtilsSettingsActivity
 import de.lemke.commonutils.ui.activity.CommonUtilsSettingsActivity
-import de.lemke.geticon.App
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -33,13 +35,13 @@ import org.robolectric.annotation.GraphicsMode
 import de.lemke.commonutils.R as commonutilsR
 
 // sdk = [36]: Robolectric 4.16.1 max supported SDK; bump when 4.17+ adds SDK 37.
-// App::class: uses the production Hilt component so App.onCreate() initializes commonUtilsSettings.
 @RunWith(RobolectricTestRunner::class)
-@Config(application = App::class, sdk = [36])
+@Config(application = HiltTestApplication::class, sdk = [36])
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 class SettingsActivityScreenshotTest {
     @Before
     fun setup() {
+        ApplicationProvider.getApplicationContext<HiltTestApplication>().initCommonUtilsSettingsAndSetDarkMode()
         commonUtilsSettings.lastVersionCode = Int.MAX_VALUE
         commonUtilsSettings.acceptedTosVersion = Int.MAX_VALUE
         setupCommonUtilsSettingsActivity(

--- a/app/src/test/java/de/lemke/geticon/ui/SettingsActivityScreenshotTest.kt
+++ b/app/src/test/java/de/lemke/geticon/ui/SettingsActivityScreenshotTest.kt
@@ -26,6 +26,7 @@ import de.lemke.commonutils.data.commonUtilsSettings
 import de.lemke.commonutils.data.initCommonUtilsSettingsAndSetDarkMode
 import de.lemke.commonutils.setupCommonUtilsSettingsActivity
 import de.lemke.commonutils.ui.activity.CommonUtilsSettingsActivity
+import de.lemke.geticon.bypassOobe
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -42,8 +43,7 @@ class SettingsActivityScreenshotTest {
     @Before
     fun setup() {
         ApplicationProvider.getApplicationContext<HiltTestApplication>().initCommonUtilsSettingsAndSetDarkMode()
-        commonUtilsSettings.lastVersionCode = Int.MAX_VALUE
-        commonUtilsSettings.acceptedTosVersion = Int.MAX_VALUE
+        commonUtilsSettings.bypassOobe()
         setupCommonUtilsSettingsActivity(
             commonutilsR.xml.preferences_design,
             commonutilsR.xml.preferences_general_language_and_image_save_location,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ targetSdk = "37"
 #noinspection UnusedVersionCatalogEntry
 jvmTarget = "21"
 
-aboutlibraries = "15.0.0"
+aboutlibraries = "15.0.1"
 androidx-test-core = "1.7.0"
 androidx-test-espresso = "3.7.0"
 androidx-test-ext-junit = "1.3.0"


### PR DESCRIPTION
## Summary

- Replaces `activity.window.decorView.captureRoboImage(...)` with `onView(isRoot()).captureRoboImage(...)` across all three screenshot test classes (`MainActivityScreenshotTest`, `SettingsActivityScreenshotTest`, `IconActivityScreenshotTest`)
- Removes manual `shadowOf(Looper.getMainLooper()).idle()` calls — Espresso handles main-thread idle implicitly
- Verified pixel-identical output against existing golden screenshots via `verifyRoborazziDebug`

## Why

`onView(isRoot())` is the primary View-based capture pattern in the official Roborazzi README and aligns with how NIA structures its equivalent (`composeTestRule.onRoot()`). It reduces nesting, removes per-test idle-wait judgment calls, and is consistent across all tests regardless of complexity.

## Test plan

- [x] `verifyRoborazziDebug` passes — all 12 golden screenshots match pixel-perfectly
- [x] Full CI green: `spotlessCheck`, `detekt`, `lintDebug`, `testDebugUnitTest`, `koverVerifyDebug`, `assembleRelease`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Refactored Robolectric screenshot tests to capture from the root view using `onView(isRoot()).captureRoboImage(...)` (instead of `decorView`) and removed manual main-looper idling in favor of Espresso synchronization. Consolidated onboarding bypass logic into `SettingsRepository.bypassOobe()`, switched screenshot tests to `HiltTestApplication` setup, and bumped the `aboutlibraries` version to `15.0.1`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->