### PR TITLE
ci: apply ci-gradle.properties in every workflow

### DIFF
--- a/.github/ci-gradle.properties
+++ b/.github/ci-gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.daemon=false
 org.gradle.parallel=true
-org.gradle.workers.max=2
+org.gradle.workers.max=3
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.parallel=true
 # Each CI job starts from a fresh checkout (only ~/.gradle is cached by setup-gradle, not

--- a/.github/workflows/baseline-profile.yml
+++ b/.github/workflows/baseline-profile.yml
@@ -17,6 +17,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           persist-credentials: false
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
       - name: Set up JDK
         uses: actions/setup-java@v6
         with:

--- a/.github/workflows/buildAndPublishRelease.yml
+++ b/.github/workflows/buildAndPublishRelease.yml
@@ -30,6 +30,9 @@ jobs:
         with:
           fetch-depth: 2
 
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
+
       - name: Set up JDK
         uses: actions/setup-java@v6
         with:


### PR DESCRIPTION
## Summary
- `.github/ci-gradle.properties` was only copied into `~/.gradle` in `ci.yml`; the other workflows ran on the project `gradle.properties` alone. Now copied in every workflow, matching Now in Android.
- `org.gradle.workers.max=3` for the 4 vCPU public-repo runner (leaves a core for the GMD emulator).
- File is byte-identical across GetIcon, OneUrl, Sudoku, OneUI-Sample-App and common-utils.

## Test plan
- [ ] `ci.yml` green (same settings as before apart from `workers.max`)
- [ ] next release / baseline-profile run shows the `Copy CI gradle.properties` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PVovcVhe9HdteaR1tET1ZS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Apply shared CI Gradle properties in baseline-profile and release workflows.
- Increase `org.gradle.workers.max` from 2 to 3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->